### PR TITLE
'AttributeError: NoneType object has no attribute quit'  on sigint

### DIFF
--- a/pgi/overrides/GLib.py
+++ b/pgi/overrides/GLib.py
@@ -548,8 +548,8 @@ class MainLoop(GLib.MainLoop):
     # Retain classic pygobject behaviour of quitting main loops on SIGINT
     def __init__(self, context=None):
         def _handler(loop):
-            loop.quit()
-            loop._quit_by_sigint = True
+            self.quit()
+            self._quit_by_sigint = True
             # We handle signal deletion in __del__, return True so GLib
             # doesn't do the deletion for us.
             return True


### PR DESCRIPTION
Fixed the 'AttributeError: NoneType object has no attribute quit'  raised when the sigint signal is received by the mainloop