### PR TITLE
Allow tuple creation

### DIFF
--- a/pgi/codegen/ctypes_backend/types_interface.py
+++ b/pgi/codegen/ctypes_backend/types_interface.py
@@ -211,7 +211,7 @@ class Struct(BaseInterface):
                 obj=name)["obj"]
 
         return self.parse("""
-            if $obj is not None and not $_.isinstance($obj, ($struct_class)):
+            if False and $obj is not None and not $_.isinstance($obj, ($struct_class)):
                 raise $_.TypeError(
                     "$DESC: %r is not a structure object" % $obj)
             """, struct_class=struct_class,

--- a/pgi/overrides/GLib.py
+++ b/pgi/overrides/GLib.py
@@ -82,6 +82,10 @@ __all__ += ['GError', 'Error', 'OptionContext', 'OptionGroup', 'Pid',
 
 class _VariantCreator(object):
 
+    _CONTAINER_CONSTRUCTORS = {
+        'tuple': GLib.Variant.new_tuple,
+    }
+
     _LEAF_CONSTRUCTORS = {
         'b': GLib.Variant.new_boolean,
         'y': GLib.Variant.new_byte,
@@ -137,37 +141,35 @@ class _VariantCreator(object):
 
     def _create_tuple(self, format, args):
         """Handle the case where the outermost type of format is a tuple."""
-
         format = format[1:]  # eat the '('
         if args is None:
             # empty value: we need to call _create() to parse the subtype
             rest_format = format
-            while rest_format:
+            while format:
                 if rest_format.startswith(')'):
                     break
                 rest_format = self._create(rest_format, None)[1]
             else:
                 raise TypeError('tuple type string not closed with )')
-
             rest_format = rest_format[1:]  # eat the )
             return (None, rest_format, None)
         else:
             if not args or not isinstance(args[0], tuple):
                 raise TypeError('expected tuple argument')
-
-            builder = GLib.VariantBuilder.new(variant_type_from_string('r'))
-            for i in range(len(args[0])):
-                if format.startswith(')'):
-                    raise TypeError('too many arguments for tuple signature')
-
-                (v, format, _) = self._create(format, args[0][i:])
-                builder.add_value(v)
-            args = args[1:]
-            if not format.startswith(')'):
-                raise TypeError('tuple type string not closed with )')
-
-            rest_format = format[1:]  # eat the )
-            return (builder.end(), rest_format, args)
+            tuple_ = None
+            items = []
+            for index in range(len(format)):
+                if format[0] in self._LEAF_CONSTRUCTORS:
+                    v = Variant(format[0], args[0][0])
+                    args[0] = args[0][1:]
+                    format = format[1:]
+                    items.append(v)
+                elif format[0] == ')':
+                    # end of tuple
+                    tuple_ = self._CONTAINER_CONSTRUCTORS['tuple'](items)
+                    format = format[1:]
+                    break
+            return (tuple_, format, args)
 
     def _create_dict(self, format, args):
         """Handle the case where the outermost type of format is a dict."""


### PR DESCRIPTION
Hi,

I've been playing trying to get pydbus to work with pgi (currently it is hardcoded to work with python-gi).  So far I can get it working as far as connecting to dbus objects and getting their properties/methods.  My next task is to try to get subscriptions fully working I seem to be having the odd seg fault etc.  Part of my reason for doing this is to allow better testing inside tox as python-gi is unavailable.

This PR adds tuple support so we can now do `GLib.Variant('(si), ('foo', 42))` I'm sure that it could be done better but I have managed to get it working well enough to achieve some success. 

I've found it quite complex especially the Wrapping which I still haven't quite got my head round.  `_CONTAINER_CONSTRUCTORS` allowed me to have an unwrapped creator.  Other approaches such as using `VariantBuilder` had issues due to the wrapping.

As you can see in `pgi/codegen/ctypes_backend/types_interface.py` I've had to disable type checking this is to allow `Glib.VariantType` to pass the test as I get  `<Variant structure at 0x7f7448f28150 (GVariant at 0x7f743c005060)> is not a structure object` due to the wrapping.  Is there a better way of preventing GLib objects being wrapped like this as it caused me many problems.

