### PR TITLE
Implement array field getter.

### DIFF
--- a/pgi/codegen/fields.py
+++ b/pgi/codegen/fields.py
@@ -188,10 +188,12 @@ class ArrayField(Field):
             self.py_type = [elm_type.py_type]
 
     def get(self, name):
-        return None, "None"
+        var = self.backend.get_type(self.type)
+        out = var.unpack(name, None)
+        return var.block, out
 
     def set(self, name, value_name):
-        return None, ""
+        raise NotImplementedError("Array setters are not implemented")
 
 
 class Utf8Field(BasicField):

--- a/tests/tests_mixed/test_dbusnodeinfo.py
+++ b/tests/tests_mixed/test_dbusnodeinfo.py
@@ -1,0 +1,32 @@
+# Copyright 2016 Linus Lewandowski
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+import unittest
+
+from gi.repository import Gio
+
+xml = """<node>
+    <interface name='net.lvht.Foo1'>
+        <method name='HelloWorld'>
+            <arg type='s' name='a' direction='in'/>
+            <arg type='i' name='b' direction='in'/>
+            <arg type='s' name='response' direction='out'/>
+        </method>
+    </interface>
+</node>"""
+
+
+class DBusNodeInfoTest(unittest.TestCase):
+
+    def test_interfaces(self):
+        ni = Gio.DBusNodeInfo.new_for_xml(xml)
+        assert(isinstance(ni, Gio.DBusNodeInfo))
+        interface = ni.lookup_interface("net.lvht.Foo1")
+        assert(isinstance(interface, Gio.DBusInterfaceInfo))
+        assert(len(ni.interfaces) == 1)
+        #assert(ni.interfaces[0] == interface)
+        assert(ni.interfaces[0].name == interface.name)


### PR DESCRIPTION
Another patch made while trying to run pydbus on pgi.

BTW: On pygi, ni.interfaces[0] == interface - and on pgi it's not true; however I don't need that for pydbus, and it should be implemented elsewhere (probably __eq__ implementation on structures).